### PR TITLE
Updated git url to github repo, since bitbucket was returning a 404

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@bitbucket.org:tenphi/gulp-revplace.git"
+    "url": "https://github.com/tenphi/gulp-revplace"
   },
   "keywords": [
     "assets",


### PR DESCRIPTION
Not sure if you primarily host this repo as a private repo on bitbucket, or what, but the published link on npmjs.com was returning a Bitbucket 404 page when I navigated to it. 
